### PR TITLE
fix(docs): add and normalize id anchors in headings for better nav

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
-# Obra-Studio/shadcn-ui-kit
+# Obra-Studio/shadcn-ui-kit {#obra-studio-shadcn-ui-kit}
 
-## What is this repo for?
+## What is this repo for? {#what-is-this-repo-for}
 
 This is the repository for
 
 * the documentation website at [shadcn.obra.studio](https://shadcn.obra.studio/). 
 * to discuss any issues with the kit within [GitHub issues](https://github.com/Obra-Studio/shadcn-ui-kit/issues).
-## What is Obra-Studio/shadcn-ui-kit?
+## What is Obra-Studio/shadcn-ui-kit? {#what-is-obra-studio-shadcn-ui-kit}
 
 This is a design library file that implements https://ui.shadcn.com/.
 
@@ -14,7 +14,7 @@ This is a design library file that implements https://ui.shadcn.com/.
 
 For more info, see the [docs](https://shadcn.obra.studio/).
 
-## Contributing
+## Contributing {#contributing}
 
 If you are interested in contributing, please read the issues at https://github.com/Obra-Studio/shadcn-ui-kit/issues .
 
@@ -22,6 +22,6 @@ We'd like to have a healthy discourse about the kit and how to use it. Feel free
 
 _Currently, the kit is in public beta until September 2025, after which we will release a final 1.0 version of the kit_
 
-## About Obra Studio
+## About Obra Studio {#about-obra-studio}
 
 [Obra Studio](https://obra.studio/) is a design studio that helps software companies get to the next design level. 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,8 +1,8 @@
-# Obra shadcn ui docs
+# Obra shadcn ui docs {#obra-shadcn-ui-docs}
 
 Using sveltekit.
 
-## Creating a project
+## Creating a project {#creating-a-project}
 
 If you're seeing this, you've probably already done this step. Congrats!
 
@@ -14,7 +14,7 @@ npx sv create
 npx sv create my-app
 ```
 
-## Developing
+## Developing {#developing}
 
 Once you've created a project and installed dependencies with `npm install` (or `pnpm install` or `yarn`), start a development server:
 
@@ -25,7 +25,7 @@ npm run dev
 npm run dev -- --open
 ```
 
-## Building
+## Building {#building}
 
 To create a production version of your app:
 

--- a/docs/src/routes/blog/(posts)/1000/+page.md
+++ b/docs/src/routes/blog/(posts)/1000/+page.md
@@ -17,4 +17,4 @@ Despite this number, we haven't received that much feedback yet. From my experie
 * If you build something with our kit, we would love to see it! Show it off in a new issue at [GitHub Issues](https://github.com/Obra-Studio/shadcn-ui-kit/issues) or tweet to [@obra_studio_2](https://twitter.com/obra_studio_2). 
 * If you have any comment or suggestion, it's more than welcome at our [GitHub Issues](https://github.com/Obra-Studio/shadcn-ui-kit/issues).
 
-Currently, we are planning to add some videos to YouTube to make it more clear how the kit can be used. Check out the existing videos [here](/videos). These videos will also serve as Figma tutorials. If you have any specific video requests, something that you wanted to know about Figma and never dared to ask, also feel free to put this in the GitHub issue. 
+Currently, we are planning to add some videos to YouTube to make it more clear how the kit can be used. Check out the existing videos [here](/videos). These videos will also serve as Figma tutorials. If you have any specific video requests, something that you wanted to know about Figma and never dared to ask, also feel free to put this in the GitHub issue.

--- a/docs/src/routes/changelog/content.md
+++ b/docs/src/routes/changelog/content.md
@@ -1,40 +1,40 @@
-# Changelog
+# Changelog {#changelog}
 
-## 0.1.5
+## 0.1.5 {#v-0-1-5}
 
 ### July 2, 2025
 
 * Bugfix: Decoration left and Decoration right did not provide an overridable icon. This component is used inside of Inputs, Select and Comboboxes to provide a way to set up an icon on the left or right side.
 
-## 0.1.4
+## 0.1.4 {#v-0-1-4}
 
 ### June 20, 2025
 
 * Component properties fixed inside the Select Field. The decoration did not have the right variance, this got changed inadvertently during the cleanup phase of our kit. . Thanks Jorre Vandenbusche for the report.
 * Added more date- and time picker examples from the ShadCN calendar drop. Thanks for designing these, Jorre Vandenbusche.
 
-## 0.1.3
+## 0.1.3 {#v-0-1-3}
 
 ### June 19, 2025
 
 * Rename a missing component property name in Field > Horizontal Field (Slider)
 * Fix auto layout for vertical variant of separator component
 
-## 0.1.2
+## 0.1.2 {#v-0-1-2}
 
 ### June 17, 2025
 
 - Added link to the docs website to the main description in the Figma community file as well as in “The basics”
 - Rename “skin” component property to “variant” to accord to shadcn codebase
 
-## 0.1.1
+## 0.1.1 {#v-0-1-1}
 
 ### June 16, 2025
 
 - Correction on Typography: we ended up using Geist, not inter. Thanks Jorre Vandenbusche for the report.
 - Added more context to hover card accessibility issue by linking to Github issue
 
-### 0.1.0 (Public beta)
+### 0.1.0 (Public beta) {#v-0-1-0-public-beta}
 
 ### June 11, 2025
 

--- a/docs/src/routes/colors/content.md
+++ b/docs/src/routes/colors/content.md
@@ -1,6 +1,6 @@
-# Colors
+# Colors {#colors}
 
-## Note about colors
+## Note about colors {#note-about-colors}
 
 ![the colors we included](/colors.png)
 _Figure: the colors we included_

--- a/docs/src/routes/components/content.md
+++ b/docs/src/routes/components/content.md
@@ -1,6 +1,6 @@
-# Components
+# Components {#components}
 
-## Available components 
+## Available components {#available-components}
 
 The following [shadcn/ui components](https://ui.shadcn.com/docs/components) are available as Figma components:
 
@@ -58,13 +58,13 @@ The following [shadcn/ui components](https://ui.shadcn.com/docs/components) are 
 
 </div>
 
-## Deprecated
+## Deprecated {#deprecated}
 
 The following components are not available, since they are deprecated.
 
 * Toast
 
-## Styles
+## Styles {#styles}
 
 The following components are available as Figma styles
 

--- a/docs/src/routes/icons/content.md
+++ b/docs/src/routes/icons/content.md
@@ -1,6 +1,6 @@
-# Icons
+# Icons {#icons}
 
-## Included icons
+## Included icons {#included-icons}
 
 ![the icons we included](/icons.png)
 _Figure: the icons we included_
@@ -28,7 +28,7 @@ However there is an extra benefit to using the icons from our add-ons file: all 
 ![Example of an air vent icon and its keywords_](/keywords.png)
 _Figure: example of an air vent icon and its keywords_
 
-## List of included icons
+## List of included icons {#list-of-included-icons}
 
 <div style="columns: 15rem">
 

--- a/docs/src/routes/intro-content-1.svx
+++ b/docs/src/routes/intro-content-1.svx
@@ -1,4 +1,4 @@
-# Intro
+# Intro {#intro}
 
 Hi! Welcome to the documentation for Obra shadcn/ui.
 

--- a/docs/src/routes/intro-content-2.svx
+++ b/docs/src/routes/intro-content-2.svx
@@ -6,7 +6,7 @@
 ![zoomed-out-view.png](/zoomed-out-view.png)
 _Figure: zoomed out view of the components_
 
-## Credits
+## Credits {#credits}
 
 Every layer and component was designed from scratch by the [Obra Studio](https://obra.studio) team, referencing the official v4 documentation. Nothing was copied or pasted from existing files or UI kits.
 
@@ -14,7 +14,7 @@ The tailwind colours were sourced from [Yusuf Matra’s kit](https://www.figma.c
 
 The only external assets used are icons from Lucide Icons. You can view their license [here](https://lucide.dev/license). (Note that the license is ISC not MIT for the Feather part of Lucide icons)
 
-## How to use this kit
+## How to use this kit {#how-to-use-this-kit}
 
 This kit is meant to be customised further. It’s the start of your own system. Just like shadcn/ui, this is not a component library. It’s how you start building your component library.
 
@@ -26,12 +26,12 @@ To make the kit your own, we recommend to:
 
 Then, consume the library from another file. You can use the bookmark icon in the assets panel to find the controls to do so.
 
-## Comments? Issues with this kit?
+## Comments? Issues with this kit? {#comments-issues-with-this-kit}
 
 [Please log any issues on GitHub](https://github.com/Obra-Studio/shadcn-ui-kit/issues). We welcome any feedback.
 
 (🇲🇽 Si deseas poner tus comentarios en español, simplemente hazlo!)
 
-## About Obra Studio
+## About Obra Studio {#about-obra-studio}
 
 [Obra Studio](https://obra.studio) is a design studio that helps software companies get to the next design level.

--- a/docs/src/routes/license/content.md
+++ b/docs/src/routes/license/content.md
@@ -1,4 +1,4 @@
-# License (MIT)
+# License (MIT) {#license-mit}
 
 Copyright 2025 Obra Studio BV
 

--- a/docs/src/routes/philosophy/content.md
+++ b/docs/src/routes/philosophy/content.md
@@ -1,6 +1,6 @@
-# The philosophy
+# The philosophy {#philosophy}
 
-# A stance on UI kits
+# A stance on UI kits {#a-stance-on-ui-kits}
 
 First of all I’ve always found UI kits a bit weird: if you have the ability to design, why don’t you design the kit yourself?
 
@@ -16,7 +16,7 @@ As Obra, we decided the balance had to be found between replicating the source f
 
 You might also find it lacks some features you might expect such as theming variables and dark mode. This was done on purpose to keep things editable (Read more in the technical comments)
 
-## Design changes to shadcn
+## Design changes to shadcn {#design-changes-to-shadcn}
 
 - We try to be 100% accurate with shadcn/ui. If you find any error, please let us know.
 - Color-wise we specifically reference the Tailwind colors in shadcn, not the theming colors (see technical comments)

--- a/docs/src/routes/technical-comments/content.md
+++ b/docs/src/routes/technical-comments/content.md
@@ -1,6 +1,6 @@
-# Technical comments
+# Technical comments {#technical-comments}
 
-## Guidelines on components
+## Guidelines on components {#guidelines-on-comments}
 
 * Prefer composability.
 * Use the raw tailwind colours, do not introduce a semantic layer (e.g. “primary-foreground”) in this file.
@@ -9,13 +9,13 @@
 * Use a generic text like “Label” or “Value” in components.
 * Use straight up Tailwind spacing numbers for components (1, 2, 4, 6, 8, 12, 16, 20, 24, 32, 36, 40). Using variables for numbers is cumbersome when editing them later. The same counts for border radii.
 
-## Wrapper components
+## Wrapper components {#wrapper-components}
 
 * Wrapper components such as cards, dialogs, sheets etc. present an interesting problem: we want to be consistent in our styling, but we also want to customise the content.
 * We are not a big fan of slot components, but also not a big fan of detaching. We’re hoping Figma takes note and finds some form of solution for this in the future, some kind of “native” slots?
 * To promote consistency, we went for slot components but this might take some time to wrap your head around. This video can help you to understand the concept.
   
-## Spacing and number variables
+## Spacing and number variables {#spacing-and-number-variables}
 
 The user interface for setting up number variables in Figma leads to too much clicking.
 
@@ -27,7 +27,7 @@ Spacings in this file will be linted with an external tool to be consistent and 
 
 (Todo: we did not get to actually lint everything - does anyone know a good tool? See [#12](https://github.com/Obra-Studio/shadcn-ui-kit/issues/12))
 
-## Notes on multi-tiered systems
+## Notes on multi-tiered systems {#notes-on-multi-tiered-systems}
 
 shadcn contains a semantic layer that contains, for example, a default background and foreground for cards, text etc.
 

--- a/docs/src/routes/typography/content.md
+++ b/docs/src/routes/typography/content.md
@@ -1,6 +1,6 @@
-# Typography
+# Typography {#typography}
 
-## Note about type styles
+## Note about type styles {#note-about-type-styles}
 
 ![typography.png](/typography.png)
 _Figure: the typographic styles we included_


### PR DESCRIPTION
This PR adds missing id anchors to documentation headings to improve accessibility and navigation. Now headings can be linked directly in the UI.  
Resolves #34.